### PR TITLE
Multithreaded leaderboard preset and filter summaries

### DIFF
--- a/src/Frontend/Filters/IFilterPropertyProvider.cs
+++ b/src/Frontend/Filters/IFilterPropertyProvider.cs
@@ -1,0 +1,23 @@
+﻿using System.Collections.Generic;
+
+namespace PrimeView.Frontend.Filters
+{
+	public interface IFilterPropertyProvider
+	{
+		public IList<string> FilterImplementations { get; }
+
+		public bool FilterParallelSinglethreaded { get; }
+		public bool FilterParallelMultithreaded { get; }
+
+		public bool FilterAlgorithmBase { get; }
+		public bool FilterAlgorithmWheel { get; }
+		public bool FilterAlgorithmOther { get; }
+
+		public bool FilterFaithful { get; }
+		public bool FilterUnfaithful { get; }
+
+		public bool FilterBitsUnknown { get; }
+		public bool FilterBitsOne { get; }
+		public bool FilterBitsOther { get; }
+	}
+}

--- a/src/Frontend/Filters/LeaderboardFilterPreset.cs
+++ b/src/Frontend/Filters/LeaderboardFilterPreset.cs
@@ -1,15 +1,17 @@
-﻿namespace PrimeView.Frontend.Filters
+﻿using PrimeView.Frontend.Tools;
+
+namespace PrimeView.Frontend.Filters
 {
 	public class LeaderboardFilterPreset : ResultFilterPreset
 	{
 		public LeaderboardFilterPreset()
 		{
 			Name = "Leaderboard";
-			ImplementationText = "";
-			ParallelismText = "mt";
-			AlgorithmText = "wh~ot";
-			FaithfulText = "uf";
-			BitsText = "uk~ot";
+			ImplementationText = string.Empty;
+			ParallelismText = Constants.MultithreadedTag;
+			AlgorithmText = new string[] { Constants.WheelTag, Constants.OtherTag}.JoinFilterValues();
+			FaithfulText = Constants.UnfaithfulTag;
+			BitsText = new string[] { Constants.UnknownTag, Constants.OtherTag }.JoinFilterValues();
 		}
 
 		public override bool IsFixed => true;

--- a/src/Frontend/Filters/MultithreadedLeaderboardFilterPreset.cs
+++ b/src/Frontend/Filters/MultithreadedLeaderboardFilterPreset.cs
@@ -1,15 +1,17 @@
-﻿namespace PrimeView.Frontend.Filters
+﻿using PrimeView.Frontend.Tools;
+
+namespace PrimeView.Frontend.Filters
 {
 	public class MultithreadedLeaderboardFilterPreset : ResultFilterPreset
 	{
 		public MultithreadedLeaderboardFilterPreset()
 		{
 			Name = "Multithreaded leaderboard";
-			ImplementationText = "";
-			ParallelismText = "st";
-			AlgorithmText = "wh~ot";
-			FaithfulText = "uf";
-			BitsText = "uk~ot";
+			ImplementationText = string.Empty;
+			ParallelismText = Constants.SinglethreadedTag;
+			AlgorithmText = new string[] { Constants.WheelTag, Constants.OtherTag }.JoinFilterValues();
+			FaithfulText = Constants.UnfaithfulTag;
+			BitsText = new string[] { Constants.UnknownTag, Constants.OtherTag }.JoinFilterValues();
 		}
 
 		public override bool IsFixed => true;

--- a/src/Frontend/Filters/MultithreadedLeaderboardFilterPreset.cs
+++ b/src/Frontend/Filters/MultithreadedLeaderboardFilterPreset.cs
@@ -1,0 +1,17 @@
+﻿namespace PrimeView.Frontend.Filters
+{
+	public class MultithreadedLeaderboardFilterPreset : ResultFilterPreset
+	{
+		public MultithreadedLeaderboardFilterPreset()
+		{
+			Name = "Multithreaded leaderboard";
+			ImplementationText = "";
+			ParallelismText = "st";
+			AlgorithmText = "wh~ot";
+			FaithfulText = "uf";
+			BitsText = "uk~ot";
+		}
+
+		public override bool IsFixed => true;
+	}
+}

--- a/src/Frontend/Filters/ResultFilterPreset.cs
+++ b/src/Frontend/Filters/ResultFilterPreset.cs
@@ -1,8 +1,11 @@
-﻿using System.Text.Json.Serialization;
+﻿using PrimeView.Frontend.Tools;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Json.Serialization;
 
 namespace PrimeView.Frontend.Filters
 {
-	public class ResultFilterPreset
+	public class ResultFilterPreset : IFilterPropertyProvider
 	{
 		[JsonPropertyName("nm")]
 		public string Name { get; set; }
@@ -24,5 +27,38 @@ namespace PrimeView.Frontend.Filters
 
 		[JsonIgnore]
 		public virtual bool IsFixed => false;
+
+		public IList<string> FilterImplementations
+			=> ImplementationText.SplitFilterValues();
+
+		public bool FilterParallelSinglethreaded 
+			=> !ParallelismText.SplitFilterValues().Contains(Constants.SinglethreadedTag);
+
+		public bool FilterParallelMultithreaded
+			=> !ParallelismText.SplitFilterValues().Contains(Constants.MultithreadedTag);
+
+		public bool FilterAlgorithmBase 
+			=> !AlgorithmText.SplitFilterValues().Contains(Constants.BaseTag);
+
+		public bool FilterAlgorithmWheel
+			=> !AlgorithmText.SplitFilterValues().Contains(Constants.WheelTag);
+
+		public bool FilterAlgorithmOther
+			=> !AlgorithmText.SplitFilterValues().Contains(Constants.OtherTag);
+
+		public bool FilterFaithful
+			=> !FaithfulText.SplitFilterValues().Contains(Constants.FaithfulTag);
+
+		public bool FilterUnfaithful
+			=> !FaithfulText.SplitFilterValues().Contains(Constants.UnfaithfulTag);
+
+		public bool FilterBitsUnknown
+			=> !BitsText.SplitFilterValues().Contains(Constants.UnknownTag);
+
+		public bool FilterBitsOne
+			=> !BitsText.SplitFilterValues().Contains(Constants.OneTag);
+
+		public bool FilterBitsOther
+			=> !BitsText.SplitFilterValues().Contains(Constants.OtherTag);
 	}
 }

--- a/src/Frontend/Pages/ReportDetails.razor
+++ b/src/Frontend/Pages/ReportDetails.razor
@@ -47,11 +47,21 @@
 					</div>
 				</div>
 
+				@{ 
+					string filterSummary = string.Empty;
+
+					if (HideFilters)
+					{
+						filterSummary = $": {this.CreateSummary(this)}";
+						if (OnlyHighestPassesPerSecondPerThreadPerLanguage)
+							filterSummary += ", only show highest passes/s/t";
+					}
+				}
 				<div class="card">
 					<div class="card-header">
 						<h2 class="mb-0">
 							<button class="btn btn-block text-primary text-left" @onclick="ToggleFilterPanel">
-								<i class="fa @(HideFilters ? "fa-angle-right" : "fa-angle-down")"></i>&nbsp;&nbsp;Filter
+								<i class="fa @(HideFilters ? "fa-angle-right" : "fa-angle-down")"></i>&nbsp;&nbsp;Filter@(filterSummary)
 							</button>
 						</h2>
 					</div>
@@ -148,7 +158,7 @@
 							</div>
 						</div>
 						<div class="row mx-2 mb-3">
-							<div class="col">
+							<div class="col-auto">
 								<button class="btn btn-primary" disabled="@AreFiltersClear" @onclick="ClearFilters">Clear filter</button>
 							</div>
 						</div>
@@ -186,7 +196,7 @@
 
 									<div class="list-group-item py-1 pl-2 pr-0 d-flex justify-content-between align-items-center">
 										<button class="btn btn-link @(preset.IsFixed ? "text-dark" : (string.Equals(preset.Name, filterPresetName?.Trim(), StringComparison.OrdinalIgnoreCase)) ? "text-success" : "text-primary") px-1 text-left " @onclick="async () => await ApplyFilterPreset(presetIndex)">
-											@preset.Name
+											@preset.Name <span class="font-italic text-secondary">(@preset.CreateSummary(this))</span>
 										</button>
 										<button class="btn btn-danger" style="box-shadow: none" disabled="@(preset.IsFixed)" @onclick="() => RemoveFilterPreset(presetIndex)">
 											<i class="fas fa-minus"></i>

--- a/src/Frontend/Pages/ReportDetails.razor.cs
+++ b/src/Frontend/Pages/ReportDetails.razor.cs
@@ -16,7 +16,7 @@ using System.Threading.Tasks;
 
 namespace PrimeView.Frontend.Pages
 {
-	public partial class ReportDetails : SortedTablePage<Result>
+	public partial class ReportDetails : SortedTablePage<Result>, IFilterPropertyProvider, ILanguageInfoProvider
 	{
 		private const string FilterPresetStorageKey = "ResultFilterPresets";
 
@@ -47,58 +47,58 @@ namespace PrimeView.Frontend.Pages
 		[QueryStringParameter("fp")]
 		public string FilterParallelismText
 		{
-			get => JoinFilterValueString(!FilterParallelSinglethreaded, "st", !FilterParallelMultithreaded, "mt");
+			get => JoinFilterValueString(!FilterParallelSinglethreaded, Constants.SinglethreadedTag, !FilterParallelMultithreaded, Constants.MultithreadedTag);
 
 			set
 			{
-				var values = SplitFilterValueString(value);
+				var values = value.SplitFilterValues();
 
-				FilterParallelSinglethreaded = !values.Contains("st");
-				FilterParallelMultithreaded = !values.Contains("mt");
+				FilterParallelSinglethreaded = !values.Contains(Constants.SinglethreadedTag);
+				FilterParallelMultithreaded = !values.Contains(Constants.MultithreadedTag);
 			}
 		}
 
 		[QueryStringParameter("fa")]
 		public string FilterAlgorithmText
 		{
-			get => JoinFilterValueString(!FilterAlgorithmBase, "ba", !FilterAlgorithmWheel, "wh", !FilterAlgorithmOther, "ot");
+			get => JoinFilterValueString(!FilterAlgorithmBase, Constants.BaseTag, !FilterAlgorithmWheel, Constants.WheelTag, !FilterAlgorithmOther, Constants.OtherTag);
 
 			set
 			{
-				var values = SplitFilterValueString(value);
+				var values = value.SplitFilterValues();
 
-				FilterAlgorithmBase = !values.Contains("ba");
-				FilterAlgorithmWheel = !values.Contains("wh");
-				FilterAlgorithmOther = !values.Contains("ot");
+				FilterAlgorithmBase = !values.Contains(Constants.BaseTag);
+				FilterAlgorithmWheel = !values.Contains(Constants.WheelTag);
+				FilterAlgorithmOther = !values.Contains(Constants.OtherTag);
 			}
 		}
 
 		[QueryStringParameter("ff")]
 		public string FilterFaithfulText
 		{
-			get => JoinFilterValueString(!FilterFaithful, "ff", !FilterUnfaithful, "uf");
+			get => JoinFilterValueString(!FilterFaithful, Constants.FaithfulTag, !FilterUnfaithful, Constants.UnfaithfulTag);
 
 			set
 			{
-				var values = SplitFilterValueString(value);
+				var values = value.SplitFilterValues();
 
-				FilterFaithful = !values.Contains("ff");
-				FilterUnfaithful = !values.Contains("uf");
+				FilterFaithful = !values.Contains(Constants.FaithfulTag);
+				FilterUnfaithful = !values.Contains(Constants.UnfaithfulTag);
 			}
 		}
 
 		[QueryStringParameter("fb")]
 		public string FilterBitsText
 		{
-			get => JoinFilterValueString(!FilterBitsUnknown, "uk", !FilterBitsOne, "on", !FilterBitsOther, "ot");
+			get => JoinFilterValueString(!FilterBitsUnknown, Constants.UnknownTag, !FilterBitsOne, Constants.OneTag, !FilterBitsOther, Constants.OtherTag);
 
 			set
 			{
-				var values = SplitFilterValueString(value);
+				var values = value.SplitFilterValues();
 
-				FilterBitsUnknown = !values.Contains("uk");
-				FilterBitsOne = !values.Contains("on");
-				FilterBitsOther = !values.Contains("ot");
+				FilterBitsUnknown = !values.Contains(Constants.UnknownTag);
+				FilterBitsOne = !values.Contains(Constants.OneTag);
+				FilterBitsOther = !values.Contains(Constants.OtherTag);
 			}
 		}
 
@@ -106,7 +106,7 @@ namespace PrimeView.Frontend.Pages
 		public bool OnlyHighestPassesPerSecondPerThreadPerLanguage { get; set; } = false;
 
 		public IList<string> FilterImplementations
-			=> SplitFilterValueString(FilterImplementationText);
+			=> FilterImplementationText.SplitFilterValues();
 
 		public bool FilterParallelSinglethreaded { get; set; } = true;
 		public bool FilterParallelMultithreaded { get; set; } = true;
@@ -237,7 +237,7 @@ namespace PrimeView.Frontend.Pages
 			base.OnTableRefreshStart();
 		}
 
-		private LanguageInfo GetLanguageInfo(string language)
+		public LanguageInfo GetLanguageInfo(string language)
 		{
 			if (this.languageMap == null)
 				this.languageMap = new();
@@ -267,12 +267,8 @@ namespace PrimeView.Frontend.Pages
 					setFlags.Add(flagSet[i + 1].ToString());
 			}
 
-			return setFlags.Count > 0 ? string.Join("~", setFlags) : string.Empty;
+			return setFlags.JoinFilterValues();
 		}
-
-		private static IList<string> SplitFilterValueString(string text) 
-			=> text.Split("~", StringSplitOptions.RemoveEmptyEntries);
-
 
 		private bool IsFilterPresetNameValid(string name)
 			=> !string.IsNullOrWhiteSpace(name)

--- a/src/Frontend/Pages/ReportDetails.razor.cs
+++ b/src/Frontend/Pages/ReportDetails.razor.cs
@@ -186,6 +186,7 @@ namespace PrimeView.Frontend.Pages
 				this.filterPresets = new();
 
 			InsertFilterPreset(new LeaderboardFilterPreset());
+			InsertFilterPreset(new MultithreadedLeaderboardFilterPreset());
 
 			await base.OnInitializedAsync();
 		}

--- a/src/Frontend/Tools/Constants.cs
+++ b/src/Frontend/Tools/Constants.cs
@@ -7,5 +7,15 @@
 		public const string SolutionUrlTemplate = nameof(SolutionUrlTemplate);
 		public const string Readers = nameof(Readers);
 		public const string JsonFileReader = nameof(JsonFileReader);
+
+		public const string SinglethreadedTag = "st";
+		public const string MultithreadedTag = "mt";
+		public const string BaseTag = "ba";
+		public const string WheelTag = "wh";
+		public const string OtherTag = "ot";
+		public const string FaithfulTag = "ff";
+		public const string UnfaithfulTag = "uf";
+		public const string UnknownTag = "uk";
+		public const string OneTag = "on";
 	}
 }

--- a/src/Frontend/Tools/ILanguageInfoProvider.cs
+++ b/src/Frontend/Tools/ILanguageInfoProvider.cs
@@ -1,0 +1,7 @@
+﻿namespace PrimeView.Frontend.Tools
+{
+	public interface ILanguageInfoProvider
+	{
+		public LanguageInfo GetLanguageInfo(string language);
+	}
+}


### PR DESCRIPTION
This PR adds:

- A baked-in preset for a multithreaded leaderboard. Filter settings are the same as the existing leaderboard, except it shows multithreaded results instead of single-threaded ones.
- Filter summaries to the filter card header when it's collapsed, and to preset labels (baked in or self-defined)