### PR TITLE
Add PDL as a known language

### DIFF
--- a/src/Frontend/wwwroot/data/langmap.json
+++ b/src/Frontend/wwwroot/data/langmap.json
@@ -214,6 +214,11 @@
 		"name": "Pascal",
 		"url": "https://en.wikipedia.org/wiki/Pascal_(programming_language)"
 	},
+	"pdl": {
+		"name": "Perl Data Language",
+		"url": "https://dpl.perl.org/",
+		"tag": "PDL"
+	},
 	"perl": {
 		"name": "Perl",
 		"url": "https://www.perl.org/"


### PR DESCRIPTION
Adds PDL as a recognized language, in preparation for the merge of PlummersSoftwareLLC/Primes#775.